### PR TITLE
move infra credentials to .env and configure Mosquitto in Docker

### DIFF
--- a/infrastructure/.gitignore
+++ b/infrastructure/.gitignore
@@ -1,0 +1,2 @@
+**/mosquitto/
+**/*.env

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,94 @@
+# DomusIoT - Infrastructure
+
+This project contains the Docker infrastructure for the **DomusIoT** system, including services for MySQL database, MQTT broker (Eclipse Mosquitto), and the Spring backend.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+---
+
+## Project Structure
+
+```
+infrastructure/
+├── docker-compose.yml
+├── .env                  # Must be created by the user
+├── mosquitto/            # Must be created by the user
+│   ├── config/
+│   │   └── mosquitto.conf
+│   ├── data/
+│   └── log/
+```
+
+---
+
+## 1. Creating the `.env` file
+
+Create a `.env` file inside the `infrastructure/` directory with the following content:
+
+```env
+MYSQL_DATABASE=mysql_user
+MYSQL_ROOT_PASSWORD=mysql_password
+
+SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/example
+SPRING_DATASOURCE_USERNAME=spring_user
+SPRING_DATASOURCE_PASSWORD=spring_pass
+```
+
+---
+
+## 2. Setting up the `mosquitto/` directory
+
+Create the directory structure for Mosquitto and add the `mosquitto.conf` configuration file:
+
+```bash
+mkdir -p mosquitto/config mosquitto/data mosquitto/log
+```
+
+### Basic example for `mosquitto/config/mosquitto.conf`:
+
+```conf
+persistence true
+persistence_location /mosquitto/data/
+log_dest file /mosquitto/log/mosquitto.log
+
+listener 1883
+allow_anonymous true
+```
+
+---
+
+## 3. Starting the containers
+
+After configuring the `.env` file and Mosquitto structure, run:
+
+```bash
+docker-compose up --build
+```
+
+This will start the following services:
+
+- `mysql`: MySQL database
+- `mosquitto`: MQTT broker
+- `backend`: Spring Boot backend application
+
+---
+
+## Notes
+
+- The `.env` file and the `mosquitto/` directory are listed in `.gitignore`, so they are **not versioned**. Make sure to share them manually if needed.
+- You can check container logs with `docker-compose logs -f`.
+
+---
+
+## Stopping the containers
+
+```bash
+docker-compose down
+```
+
+---
+
+Feel free to open an issue or contact the team if you need any help.

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     container_name: domusiot-mysql
     restart: always
     environment:
-      MYSQL_DATABASE: domusiot
-      MYSQL_ROOT_PASSWORD: admin
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     ports:
       - "3306:3306"
     volumes:
@@ -13,35 +13,34 @@ services:
     networks:
       - domus_net 
 
-
-#  mosquitto:
-#    image: eclipse-mosquitto
-#    container_name: domusiot-mosquitto
-#    ports:
-#      - "1883:1883"
-#      - "9001:9001"
-#    volumes:
-#      - ./mosquitto:/mosquitto
+  mosquitto:
+    image: eclipse-mosquitto
+    container_name: domusiot-mosquitto
+    ports:
+      - "1883:1883"
+      - "9001:9001"
+    volumes:
+      - ./mosquitto:/mosquitto
 
   backend:
     build:
       context: ../backend
     container_name: domusiot-backend
-    
     depends_on:
       - mysql
-#      - mosquitto
+      - mosquitto
     ports:
       - "8080:8080"
     environment:
-      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/domusiot
-      SPRING_DATASOURCE_USERNAME: root
-      SPRING_DATASOURCE_PASSWORD: admin
+      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL}
+      SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
     networks:
       - domus_net
 
 volumes:
-  mysql_data:
+ mysql_data:
 
 networks:
-  domus_net:
+ domus_net:
+


### PR DESCRIPTION
- Created `.env` file to store sensitive environment variables, removing credentials from `.yaml`
- Added `mosquitto/` directory with configuration for Mosquitto inside the Docker container
- Added `README.md` with instructions on setting environment variables and running Mosquitto with Docker