### PR TITLE
feat(device): support sending commands and subscribing to MQTT topics

### DIFF
--- a/backend/src/main/java/com/iotmanager/dto/DeviceCommandDTO.java
+++ b/backend/src/main/java/com/iotmanager/dto/DeviceCommandDTO.java
@@ -1,0 +1,33 @@
+package com.iotmanager.dto;
+
+import java.util.List;
+
+public class DeviceCommandDTO {
+    private Integer interval_min; // Opcional
+    private Integer output_status; // Opcional
+    private List<ScheduleEntry> schedules; // Opcional
+
+    public Integer getInterval_min() { return interval_min; }
+    public void setInterval_min(Integer interval_min) { this.interval_min = interval_min; }
+
+    public Integer getOutput_status() { return output_status; }
+    public void setOutput_status(Integer output_status) { this.output_status = output_status; }
+
+    public List<ScheduleEntry> getSchedules() { return schedules; }
+    public void setSchedules(List<ScheduleEntry> schedules) { this.schedules = schedules; }
+
+    public static class ScheduleEntry {
+        private int hour;
+        private int minute;
+        private int state;
+
+        public int getHour() { return hour; }
+        public void setHour(int hour) { this.hour = hour; }
+
+        public int getMinute() { return minute; }
+        public void setMinute(int minute) { this.minute = minute; }
+
+        public int getState() { return state; }
+        public void setState(int state) { this.state = state; }
+    }
+}

--- a/backend/src/main/java/com/iotmanager/model/Device.java
+++ b/backend/src/main/java/com/iotmanager/model/Device.java
@@ -1,5 +1,6 @@
 package com.iotmanager.model;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -10,7 +11,7 @@ public class Device {
 	@Id
 	@GeneratedValue
 	private Long id;
-
+	@Column(unique = true, nullable = false)
 	private String serial;
 	private double latitude;
 	private double longitude;

--- a/backend/src/main/java/com/iotmanager/service/DeviceService.java
+++ b/backend/src/main/java/com/iotmanager/service/DeviceService.java
@@ -30,4 +30,9 @@ public class DeviceService {
     public void deleteDevice(Long id) {
         deviceRepository.deleteById(id);
     }
+    
+    public boolean serialExists(String serial) {
+        return deviceRepository.findBySerial(serial).isPresent();
+    }
+
 }

--- a/backend/src/main/java/com/iotmanager/service/MqttService.java
+++ b/backend/src/main/java/com/iotmanager/service/MqttService.java
@@ -2,6 +2,7 @@ package com.iotmanager.service;
 
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.UUID;
 
 import org.eclipse.paho.client.mqttv3.IMqttClient;
@@ -9,7 +10,14 @@ import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.iotmanager.dto.DeviceCommandDTO;
+import com.iotmanager.model.Device;
+
+import jakarta.annotation.PostConstruct;
 
 @Service
 public class MqttService {
@@ -19,23 +27,67 @@ public class MqttService {
 
     private IMqttClient client;
 
+    @Autowired
+    private DeviceService deviceService;
+
     public MqttService() {
         this.client = null;
     }
 
-    public void publishCommand(String deviceSerial, String command) {
+    public void publishCommand(String deviceSerial, DeviceCommandDTO command) {
         try {
             if (client == null || !client.isConnected()) {
                 reconnect();
             }
 
-            String topic = "device/" + deviceSerial + "/cmd";
-            MqttMessage message = new MqttMessage(command.getBytes(StandardCharsets.UTF_8));
+            String topic = "/domus01/downlink/" + deviceSerial;
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            String payload = objectMapper.writeValueAsString(command);
+
+            System.out.println("✅ Publishing to topic: " + topic);
+            System.out.println("📦 Payload: " + payload);
+
+            MqttMessage message = new MqttMessage(payload.getBytes(StandardCharsets.UTF_8));
             message.setQos(1);
             message.setRetained(false);
 
             client.publish(topic, message);
+
+        } catch (Exception e) {
+            e.printStackTrace(); 
+        }
+    }
+
+    public void subscribeToDevice(String deviceSerial) {
+        try {
+            if (client == null || !client.isConnected()) {
+                reconnect();
+            }
+
+            String topic = "/domus01/uplink/" + deviceSerial;
+            client.subscribe(topic, (t, msg) -> {
+                String payload = new String(msg.getPayload(), StandardCharsets.UTF_8);
+                System.out.println("📡 Message received from [" + t + "]: " + payload);
+                // Optionally process the payload here
+            });
+
+            System.out.println("✅ Subscribed to topic: " + topic);
         } catch (MqttException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @PostConstruct
+    public void init() {
+        try {
+            reconnect();
+            List<Device> devices = deviceService.getAllDevices();
+            for (Device device : devices) {
+                subscribeToDevice(device.getSerial());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 
@@ -50,8 +102,10 @@ public class MqttService {
                 options.setAutomaticReconnect(true);
                 options.setCleanSession(true);
                 client.connect(options);
+                System.out.println("🔌 Connected to MQTT broker.");
             }
         } catch (MqttException e) {
+            e.printStackTrace();
         }
     }
 
@@ -59,3 +113,4 @@ public class MqttService {
         return client != null && client.isConnected();
     }
 }
+


### PR DESCRIPTION
- Added endpoint POST /api/devices/{id}/command to send MQTT commands
- Published payload to /domus01/downlink/{serial} with support for interval, output_status, and schedules
- Subscribed to /domus01/uplink/{serial} upon device registration
- Validated serial to prevent duplicate device creation
- Improved error handling for missing or duplicated serial values